### PR TITLE
Add workflow to close stale issues automatically

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: 'Close stale issues'
+
+on:
+  schedule:
+    - cron: '0 12 * * *'  # Runs daily at 20:00 UTC+8 (12:00 UTC)
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed in 7 days if no further activity occurs.'
+          close-issue-message: 'This issue has been automatically closed due to inactivity. Feel free to reopen if you still need assistance.'
+          days-before-stale: 14
+          days-before-close: 7
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'pinned,security,feature'
+          operations-per-run: 100


### PR DESCRIPTION
This workflow automatically marks issues as stale after 14 days of inactivity and closes them after an additional 7 days. It includes customizable messages for stale and closed issues.